### PR TITLE
Feature/boreas scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # vscode
 .vscode/
 
+# secrets
+.env
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/env_template
+++ b/env_template
@@ -1,0 +1,4 @@
+# Change the file name to .env to let the 
+# boto3 configuration (boreas)
+BOREAS_ACCESS_KEY_ID=
+BOREAS_SECRET_ACCESS_KEY=

--- a/generator/create_catalog.py
+++ b/generator/create_catalog.py
@@ -61,7 +61,6 @@ NO_DATA_STR = ""
 BOREAS_BUCKET_NAME = 'gdex-data'
 BOREAS_ENDPOINT_URL = 'https://boreas.hpc.ucar.edu:6443'
 
-
 def load_env():
     """
     Load .env file from the top level directory.
@@ -93,11 +92,6 @@ def load_env():
         log_error = f".env file not found at {env_file}"
         print(log_error)
         raise FileNotFoundError(log_error)
-
-load_env()
-BOREAS_ACCESS_KEY_ID = os.getenv('BOREAS_ACCESS_KEY_ID')
-BOREAS_SECRET_ACCESS_KEY = os.getenv('BOREAS_SECRET_ACCESS_KEY')
-
 
 def get_parser():
     """Returns argpars parser."""
@@ -626,7 +620,6 @@ def create_catalog(
     b.df = new_df.from_records(dict_list)
     # print(b.df)
 
-
     if output_format.lower() == 'csv_and_json':
         catalog_type = 'file'
     elif output_format.lower() == 'single_json':
@@ -712,6 +705,10 @@ def main(args_list):
 
     # Auto-populate storage_options when any directory is an s3:// path
     if any(d.startswith('s3://') for d in args_dict['directories']):
+        # load BOREAS credentials from .env file in top level directory
+        load_env()
+        BOREAS_ACCESS_KEY_ID = os.getenv('BOREAS_ACCESS_KEY_ID')
+        BOREAS_SECRET_ACCESS_KEY = os.getenv('BOREAS_SECRET_ACCESS_KEY')
         args_dict['storage_options'] = {
             's3': {
                 'client_kwargs': {'endpoint_url': BOREAS_ENDPOINT_URL},
@@ -730,4 +727,3 @@ def main(args_list):
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-

--- a/generator/create_catalog.py
+++ b/generator/create_catalog.py
@@ -28,9 +28,13 @@ Notes:
 
 Testing example:
 python create_catalog.py /lustre/desc1/scratch/chiaweih/d640000.jra3q/kerchunk_test/ --data_format reference --out /lustre/desc1/scratch/chiaweih/d640000.jra3q/catalog --output_format csv_and_json --catalog_name d640000_catalog --description "JRA3Q kerchunk catalog" --depth 0 --make_remote
+python create_catalog.py s3://gdex-data/d010096/AS-RCEC/TaiESM1/1pctCO2/r1i1p1f1/Amon/clivi/gn/ --data_format zarr --catalog_data zarr-boreas --out /lustre/desc1/scratch/chiaweih/d010096.cmip6/catalog --output_format csv_and_json --catalog_name d010096-posix --description "CMIP6 zarr catalog" --depth 0 --make_remote
+python create_catalog.py s3://gdex-data/d010096/ --data_format zarr --catalog_data zarr-boreas --out /lustre/desc1/scratch/chiaweih/d010096.cmip6/catalog --output_format csv_and_json --catalog_name d010096-posix --description "CMIP6 zarr catalog" --depth 7  --make_remote
+
 """
 # import pdb
 # import intake_esm
+
 import sys
 import os
 import re
@@ -38,6 +42,7 @@ import json
 import logging
 import argparse
 from packaging import version
+from dotenv import load_dotenv
 
 import xarray
 import pandas as pd
@@ -51,6 +56,47 @@ logger = logging.getLogger(__name__)
 
 # constant definitions
 NO_DATA_STR = ""
+
+# setup global variables for BOREAS S3 bucket
+BOREAS_BUCKET_NAME = 'gdex-data'
+BOREAS_ENDPOINT_URL = 'https://boreas.hpc.ucar.edu:6443'
+
+
+def load_env():
+    """
+    Load .env file from the top level directory.
+        
+    Returns
+    -------
+    bool
+        True if .env file was loaded successfully, False otherwise
+    """
+    # Get the directory where this utils module is located
+    utils_dir = os.path.dirname(os.path.abspath(__file__))
+    # Go up one level to get to root directory
+    root = os.path.dirname(utils_dir)
+    env_file = os.path.join(root, '.env')
+
+    log_info = f"Looking for .env file at: {env_file}"
+    print(log_info)
+
+    if os.path.exists(env_file):
+        success = load_dotenv(env_file)
+        if success:
+            log_info = f".env file loaded successfully from {env_file}"
+            print(log_info)
+        else:
+            log_error = f"Failed to load .env file from {env_file}"
+            print(log_error)
+            raise Exception(log_error)
+    else:
+        log_error = f".env file not found at {env_file}"
+        print(log_error)
+        raise FileNotFoundError(log_error)
+
+load_env()
+BOREAS_ACCESS_KEY_ID = os.getenv('BOREAS_ACCESS_KEY_ID')
+BOREAS_SECRET_ACCESS_KEY = os.getenv('BOREAS_SECRET_ACCESS_KEY')
 
 
 def get_parser():
@@ -79,6 +125,13 @@ def get_parser():
             metavar='<directory>',
             default='./',
             help="Directory to ouput catalog file.")
+    parser.add_argument('--catalog_data', '-cd',
+            type=str,
+            required=False,
+            metavar='<data>',
+            choices=['reference', 'zarr-glade', 'zarr-boreas'],
+            help='The data format of the catalog (reference / zarr-glade / zarr-boreas).',
+            default='reference')
     parser.add_argument('--catalog_name', '-n',
             type=str,
             required=False,
@@ -203,11 +256,13 @@ def get_var_attrs(var):
     return var_attrs
 
 
-def file_parser(file_path, data_format='netcdf', ignore_vars=None, var_metadata=None, global_metadata=None):
+def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_vars=None, var_metadata=None, global_metadata=None):
     """File parser used in Builder object to extract column values.
 
     Args:
         file_path (str, Path): path to data_file
+        data_format (str): data format of file. Options: 'netcdf', 'zarr', 'reference'
+        zarr_format (int): if data_format is zarr, specify zarr version (2 or 3)
         ignore_vars (list(str)): Variable names to ignore. e.g. 'utc_time'
         var_metadata (list(str)): Extra variable level metadata to pull.
             ex: ['long_name', 'standard_name']
@@ -229,7 +284,6 @@ def file_parser(file_path, data_format='netcdf', ignore_vars=None, var_metadata=
     backend_kwargs = None
 
     print(f'Gathering {file_path}')
-    engine = get_engine(file_path)
     path_str = file_path
 
     # Handle reference case
@@ -243,6 +297,30 @@ def file_parser(file_path, data_format='netcdf', ignore_vars=None, var_metadata=
         else:
             # works for kerchunk or virtualizarr references
             engine = 'kerchunk'
+    # Handle zarr case with versioning option
+    elif data_format == 'zarr':
+        engine = 'zarr'
+        if zarr_format is None:
+            zarr_format = 2
+        backend_kwargs = {'consolidated':True, 'zarr_format':int(zarr_format)}
+        
+        # change to https:// boreas internal end point if file_path is s3://
+        if re.match('s3://.*', file_path):
+            file_path = file_path.replace(
+                f's3://{BOREAS_BUCKET_NAME}/',
+                f'{BOREAS_ENDPOINT_URL}/{BOREAS_BUCKET_NAME}/'
+            )
+            path_str = file_path
+    else:
+        engine = get_engine(file_path)
+        
+
+    # try:
+    #     xarray.open_dataset(file_path, engine=engine, backend_kwargs=backend_kwargs)
+    # except Exception:
+    #     if data_format == 'zarr':
+    #         return catalog_items
+    #     raise
 
 
     with xarray.open_dataset(file_path, engine=engine, backend_kwargs=backend_kwargs) as ds:
@@ -318,7 +396,7 @@ def convert_to_parquet(filename_base):
 #     json.dump(cat, open(json_file, 'w'))
 
 
-def make_remote_catalog(filename, output_format='csv_and_json'):
+def make_remote_catalog(filename, catalog_data='reference', output_format='csv_and_json'):
     """
     Make OSDF and HTTP versions of a given file.
 
@@ -326,7 +404,13 @@ def make_remote_catalog(filename, output_format='csv_and_json'):
     ----------
     filename : str
         Local file path to the catalog file (csv or json).
-
+    catalog_data : str
+        The type of data to be cataloged, which determines how paths are modified.
+        Options are 'reference', 'zarr-boreas', and 'zarr-glade'. Default is 'reference'.
+    output_format : str
+        The format of the catalog file, which determines how the file is read and modified.
+        Options are 'csv_and_json' and 'single_json'. Default is 'csv_and_json'.
+        
     Raises
     ------
     ValueError
@@ -376,13 +460,28 @@ def make_remote_catalog(filename, output_format='csv_and_json'):
         )
 
     # define replacement strings and write new files
-    match_str = '/glade/campaign/collections/gdex/data/'
-    https_str = 'https://data.gdex.ucar.edu/'
-    # osdf_str = 'https://data-osdf.gdex.ucar.edu/'
-    osdf_str = 'osdf:///ncar/gdex/'
+    if catalog_data == 'reference':
+        match_str = '/glade/campaign/collections/gdex/data/'
+        https_str = 'https://data.gdex.ucar.edu/'
+        # osdf_str = 'https://data-osdf.gdex.ucar.edu/'
+        # osdf_str = 'osdf:///ncar/gdex/'
+        # read reference file from globus end point
+        osdf_str = https_str
+    elif catalog_data == 'zarr-boreas':
+        match_str = f'{BOREAS_ENDPOINT_URL}/{BOREAS_BUCKET_NAME}/'
+        https_str = 'https://osdata.gdex.ucar.edu/'
+        osdf_str = 'osdf:///ncar-gdex/'
+        # osdf_str = 'https://osdf-director.osg-htc.org/ncar-gdex/'
+    elif catalog_data == 'zarr-glade':
+        match_str = '/glade/campaign/collections/gdex/data/'
+        https_str = 'https://data.gdex.ucar.edu/'
+        osdf_str = 'osdf:///ncar/gdex/'
+        # osdf_str = 'https://osdf-director.osg-htc.org/ncar/gdex/'
+    else:
+        raise ValueError(f'Unsupported catalog data type: {catalog_data}')
 
 
-    if output_format.lower() == 'csv_and_json':
+    if output_format.lower() == 'csv_and_json' :
         # modify csv file line by line
         with open(filename, 'r', encoding='utf-8') as fh:
             osdf_fh = open(osdf_outfile, 'w', encoding='utf-8')
@@ -397,12 +496,13 @@ def make_remote_catalog(filename, output_format='csv_and_json'):
                 url_https = i.split(',')[0]
                 # change the path (https protocol)
                 url_https = url_https.replace(match_str, https_str)
-                # change the basename to include protocol
-                basename_https = os.path.basename(url_https)
-                rename_basename_elem_https = basename_https.split('.')
-                rename_basename_elem_https[-2] = rename_basename_elem_https[-2] + '-remote-https'
-                rename_basename_https = '.'.join(rename_basename_elem_https)
-                url_https = url_https.replace(basename_https, rename_basename_https)
+                if catalog_data == 'reference':
+                    # change the basename to include protocol
+                    basename_https = os.path.basename(url_https)
+                    rename_basename_elem_https = basename_https.split('.')
+                    rename_basename_elem_https[-2] = rename_basename_elem_https[-2] + '-remote-https'
+                    rename_basename_https = '.'.join(rename_basename_elem_https)
+                    url_https = url_https.replace(basename_https, rename_basename_https)
                 # replace path in line
                 https_new_line = i.replace(i.split(',')[0], url_https)
                 # write new line
@@ -412,12 +512,13 @@ def make_remote_catalog(filename, output_format='csv_and_json'):
                 url_osdf = i.split(',')[0]
                 # change the path (osdf protocol)
                 url_osdf = url_osdf.replace(match_str, osdf_str)
-                # change the basename to include protocol
-                basename_osdf = os.path.basename(url_osdf)
-                rename_basename_elem_osdf = basename_osdf.split('.')
-                rename_basename_elem_osdf[-2] = rename_basename_elem_osdf[-2] + '-remote-osdf'
-                rename_basename_osdf = '.'.join(rename_basename_elem_osdf)
-                url_osdf = url_osdf.replace(basename_osdf, rename_basename_osdf)
+                if catalog_data == 'reference':
+                    # change the basename to include protocol
+                    basename_osdf = os.path.basename(url_osdf)
+                    rename_basename_elem_osdf = basename_osdf.split('.')
+                    rename_basename_elem_osdf[-2] = rename_basename_elem_osdf[-2] + '-remote-osdf'
+                    rename_basename_osdf = '.'.join(rename_basename_elem_osdf)
+                    url_osdf = url_osdf.replace(basename_osdf, rename_basename_osdf)
                 # replace path in line
                 osdf_new_line = i.replace(i.split(',')[0], url_osdf)
                 # write new line
@@ -446,6 +547,7 @@ def make_remote_catalog(filename, output_format='csv_and_json'):
         with open(https_outfile, 'w') as https_fh:
             json.dump(data, https_fh)
 
+
     # elif output_format.lower() == 'parquet':
     #     df = pd.read_parquet(filename)
     #     df_osdf = df.copy(deep=True)
@@ -473,10 +575,12 @@ def make_remote_catalog(filename, output_format='csv_and_json'):
 
 def create_catalog(
     directories,
+    storage_options=None,
     out='./',
     depth=20,
     include=None,
     exclude=None,
+    catalog_data='reference',
     catalog_name=None,
     description='',
     make_remote=False,
@@ -498,12 +602,16 @@ def create_catalog(
     """
     print(kwargs)
 
+    for directory in directories:
+        if 's3://' in directory and not storage_options:
+            raise ValueError(f"Directory {directory} is an s3 path but no storage options were provided.")
 
     b = ecgtools.Builder(
         paths=directories,
         depth=depth,
         include_patterns=include,
-        exclude_patterns=exclude
+        exclude_patterns=exclude,
+        storage_options=storage_options
     )
     b.build(parsing_func=file_parser, parsing_func_kwargs=kwargs)
 
@@ -578,7 +686,7 @@ def create_catalog(
 
     if make_remote:
         remote_catalog_file = os.path.join(out,f'{catalog_name}.{file_ext}')
-        make_remote_catalog(remote_catalog_file, output_format=output_format)
+        make_remote_catalog(remote_catalog_file, catalog_data=catalog_data, output_format=output_format)
 
 
 def main(args_list):
@@ -601,11 +709,22 @@ def main(args_list):
 
     # convert args to dict
     args_dict = vars(args)
+
+    # Auto-populate storage_options when any directory is an s3:// path
+    if any(d.startswith('s3://') for d in args_dict['directories']):
+        args_dict['storage_options'] = {
+            's3': {
+                'client_kwargs': {'endpoint_url': BOREAS_ENDPOINT_URL},
+                'key': BOREAS_ACCESS_KEY_ID,
+                'secret': BOREAS_SECRET_ACCESS_KEY
+            }
+        }
+
     # remove unneeded args (for consistency with other dataset)
     args_dict.pop('global_metadata')
     args_dict.pop('var_metadata')
     # call create_catalog with args
-    print(f'Creating catalog with args: {args_dict}')
+    # print(f'Creating catalog with args: {args_dict}')
     create_catalog(**args_dict)
 
 

--- a/generator/create_catalog.py
+++ b/generator/create_catalog.py
@@ -164,16 +164,18 @@ def get_parser():
             help="Optionally ignore specific variables e.g. utc_date")
     parser.add_argument('--var_metadata', '-vm',
             type=str,
+            nargs='*',
             required=False,
-            metavar='<json string/filename>',
-            default='{}',
-            help="Additional variable level metadata to extract.")
+            metavar='<attr name>',
+            default=[],
+            help="Additional variable level metadata to extract. e.g. long_name standard_name")
     parser.add_argument('--global_metadata', '-gm',
             type=str,
+            nargs='*',
             required=False,
-            metavar='<json string/filename>',
-            default='{}',
-            help="Additional global level metadata to extract.")
+            metavar='<attr name>',
+            default=[],
+            help="Additional global level metadata to extract. e.g. member_id group_id")
     parser.add_argument('--make_remote', '-mr',
             action='store_true',
             required=False,
@@ -186,6 +188,13 @@ def get_parser():
             choices=['csv_and_json', 'single_json'],
             help='The output format of the catalog (csv_and_json / single_json).',
             default='csv_and_json')
+    parser.add_argument('--use_cftime',
+            type=lambda x: x.lower() == 'true',
+            metavar='<True|False>',
+            required=False,
+            help='Use cftime objects for time decoding instead of numpy datetime64.',
+            default=False)
+   
 
     return parser
 
@@ -249,8 +258,7 @@ def get_var_attrs(var):
                 var_attrs['level_units'] = cur_var.attrs['units']
     return var_attrs
 
-
-def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_vars=None, var_metadata=None, global_metadata=None):
+def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_vars=None, var_metadata=None, global_metadata=None, use_cftime=False):
     """File parser used in Builder object to extract column values.
 
     Args:
@@ -262,7 +270,7 @@ def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_va
             ex: ['long_name', 'standard_name']
         global_metadata (list(str)): Extra global level metadata to pull.
             ex: ['title', 'institution']
-
+        use_cftime (bool): Whether to use cftime for time decoding.
     Returns:
         dict: Keys are column names and values specific to file.
     """
@@ -275,19 +283,34 @@ def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_va
         global_metadata = []
 
     catalog_items = []
-    backend_kwargs = None
+    backend_kwargs = {}
 
     print(f'Gathering {file_path}')
     path_str = file_path
 
+    # set backend_kwarg for cftime decoding if option is set
+    if use_cftime:
+        time_coder = xarray.coders.CFDatetimeCoder(use_cftime=True)
+        backend_kwargs['decode_times'] = time_coder
+        try:
+            # test if cftime decoding works for this file
+            with xarray.open_dataset(file_path, engine=get_engine(file_path), backend_kwargs=backend_kwargs) as ds:
+                pass
+        except ValueError as e:
+            backend_kwargs['decode_times'] = False
+            print(f'Warning: cftime decoding failed for file {file_path} with error: {e}. Falling back to no time decoding.')
+    else:
+        backend_kwargs['decode_times'] = None
+
     # Handle reference case
     if data_format == 'reference':
+        print(f'Handling reference format for file: {file_path}')
         if version.parse(xarray.__version__) < version.parse('2025.9.1'):
             # original kerchunk handling in xarray
             fs = fsspec.filesystem('reference', fo=file_path)
             file_path = fs.get_mapper('')
             engine = 'zarr'
-            backend_kwargs = {'consolidated':False}
+            backend_kwargs['consolidated'] = False
         else:
             # works for kerchunk or virtualizarr references
             engine = 'kerchunk'
@@ -296,7 +319,9 @@ def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_va
         engine = 'zarr'
         if zarr_format is None:
             zarr_format = 2
-        backend_kwargs = {'consolidated':True, 'zarr_format':int(zarr_format)}
+        print(f'Handling zarr format for file: {file_path} with zarr_format: {zarr_format}')
+        backend_kwargs['consolidated'] = True
+        backend_kwargs['zarr_format'] = int(zarr_format)
         
         # change to https:// boreas internal end point if file_path is s3://
         if re.match('s3://.*', file_path):
@@ -306,7 +331,12 @@ def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_va
             )
             path_str = file_path
     else:
+        print(f'Handling netcdf/grib format for file: {file_path}')
         engine = get_engine(file_path)
+
+    # if empty reset to None for xarray compatibility
+    if backend_kwargs == {}:
+        backend_kwargs = None
         
 
     # try:
@@ -337,8 +367,9 @@ def file_parser(file_path, data_format='netcdf', zarr_format:int=None, ignore_va
             # add extra global metadata(catalog columns) and its value for each variable
             if len(global_metadata) > 0:
                 for attr in global_metadata:
-                    if attr in ds.attrs:
-                        catalog_item.update({attr:ds.attrs[attr]})
+                    # if attr in ds.attrs:
+                    globalmeta= ds.attrs.get(attr, NO_DATA_STR)
+                    catalog_item.update({attr:globalmeta})
 
             # add standard variable attributes
             catalog_item.update(get_var_attrs(var))
@@ -633,7 +664,7 @@ def create_catalog(
         path_column_name='path',
         variable_column_name='variable',
         format_column_name='format',
-        data_format='reference',
+        data_format=kwargs['data_format'],
         groupby_attrs=[
             'variable',
             'short_name'
@@ -705,6 +736,7 @@ def main(args_list):
 
     # Auto-populate storage_options when any directory is an s3:// path
     if any(d.startswith('s3://') for d in args_dict['directories']):
+        print('S3 path detected in directories, auto-populating storage_options for BOREAS S3 bucket.')
         # load BOREAS credentials from .env file in top level directory
         load_env()
         BOREAS_ACCESS_KEY_ID = os.getenv('BOREAS_ACCESS_KEY_ID')
@@ -718,8 +750,8 @@ def main(args_list):
         }
 
     # remove unneeded args (for consistency with other dataset)
-    args_dict.pop('global_metadata')
-    args_dict.pop('var_metadata')
+    # args_dict.pop('global_metadata')
+    # args_dict.pop('var_metadata')
     # call create_catalog with args
     # print(f'Creating catalog with args: {args_dict}')
     create_catalog(**args_dict)


### PR DESCRIPTION
This pull request adds support for generating catalogs from Zarr datasets stored in the BOREAS S3 object store, enhances metadata extraction flexibility, and improves configuration and automation for cloud-based workflows. The changes introduce `.env`-based credential loading, new command-line options for Zarr and metadata handling, and logic to rewrite catalog paths for different storage backends.

**Cloud and Zarr support:**
- Added support for reading Zarr datasets from the BOREAS S3 object store, including handling endpoint URLs and credentials via `.env` files, and auto-populating storage options when S3 paths are detected. (`env_template`, [[1]](diffhunk://#diff-50ce10f6ab457fed888aa2cc76d1e613e49d3e86204281c3eb304fff8b350ce7R1-R4); `generator/create_catalog.py`, [[2]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR31-R45) [[3]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR60-R94) [[4]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eL229-R347) [[5]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR736-L614)
- Introduced new command-line arguments for specifying catalog data type (`--catalog_data`), Zarr format, and using cftime for time decoding. (`generator/create_catalog.py`, [[1]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR122-R128) [[2]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR191-R197)

**Metadata extraction improvements:**
- Changed `--var_metadata` and `--global_metadata` arguments to accept lists of attribute names, making metadata extraction more flexible and user-friendly. (`generator/create_catalog.py`, [generator/create_catalog.pyR167-R178](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR167-R178))
- Improved handling of missing global metadata attributes by providing a default empty string instead of failing. (`generator/create_catalog.py`, [generator/create_catalog.pyL268-R372](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eL268-R372))

**Catalog output enhancements:**
- Enhanced the `make_remote_catalog` function to rewrite catalog paths appropriately for different backends (reference, zarr-boreas, zarr-glade), supporting both HTTPS and OSDF protocols. (`generator/create_catalog.py`, [[1]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eL321-R437) [[2]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR488-R506) [[3]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR524) [[4]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR540)

**General improvements and bug fixes:**
- Added logic to ensure that storage options are provided when S3 paths are used, and improved error handling for missing credentials or unsupported catalog types. (`generator/create_catalog.py`, [[1]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR603-R608) [[2]](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR630-R639)
- Various code cleanups, such as removing unnecessary argument popping and improving logging and error messages. (`generator/create_catalog.py`, [generator/create_catalog.pyR736-L614](diffhunk://#diff-d3a80e7189597ced4238693ef51e28fa8d37afc9f9c6e4c9d5aaa4da6551b90eR736-L614))